### PR TITLE
Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Unix Build Status][travis-image]][travis-link]
 [![Windows Build Status][appveyor-image]][appveyor-link]
 [![Coverage][codecov-image]][codecov-link]
-[![pypi-version][pypi-image]][pypi-link]
+[![PyPI Version][pypi-image]][pypi-link]
 ![License][license-image-mit]
 
 # PEP 562

--- a/docs/src/dictionary/en-custom.txt
+++ b/docs/src/dictionary/en-custom.txt
@@ -2,6 +2,7 @@ Accessors
 MERCHANTABILITY
 NONINFRINGEMENT
 Pre
+PyPI
 Vendoring
 accessor
 backport


### PR DESCRIPTION
Recent PySpelling official release fixed  a couple bugs, one being that attributes of tags with no content weren't getting scanned. With this recent fix in place, we need to adjust the dictionary to account for attributes that are now getting scanned that were not before.